### PR TITLE
Make SPADs use CDN to download updates.

### DIFF
--- a/pr-downloader.service
+++ b/pr-downloader.service
@@ -8,6 +8,8 @@ StartLimitBurst=3
 [Service]
 User=uberserver
 Type=oneshot
+Environment="PRD_RAPID_USE_STREAMER=false"
+Environment="PRD_RAPID_REPO_MASTER=https://bar-rapid.p2004a.com/repos.gz"
 ExecStart=/usr/games/pr-downloader --filesystem-writepath /home/uberserver/builds/spads/var/spring/data byar:test
 StandardOutput=journal
 Restart=on-failure

--- a/var/springsettings.cfg
+++ b/var/springsettings.cfg
@@ -8,3 +8,4 @@ LinkOutgoingBandwidth= 262144
 LinkIncomingSustainedBandwidth = 262144
 LinkIncomingPeakBandwidth = 262144 
 LinkIncomingMaxPacketRate = 2048
+RapidTagResolutionOrder = bar-rapid.p2004a.com


### PR DESCRIPTION
CDN can be behind main repo, so let's make sure that when spads uses game update, it's available for everybody.