### PR TITLE
teiserver message handler & updateSkill implementation

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -220,6 +220,17 @@ def updateTachyonBattle(key, value):
 		spads.slog("Unhandled exception: " + str(sys.exc_info()[0]) + "\n" + str(traceback.format_exc()), 0)
 	return False
 
+def onTeiServerMessage(command, args):
+	try:			
+		spads.slog("onTeiserverMsg: " + str([command, args]), DBGLEVEL)
+
+		if command == 'updateSkill':
+			for player in args:
+				perl.eval("::getBattleSkill(" + player + ")")
+
+	except Exception as e:
+		spads.slog("Unhandled exception: " + str(sys.exc_info()[0]) + "\n" + str(traceback.format_exc()), 0)
+
 # This is the class implementing the plugin
 class BarManager:
 
@@ -401,14 +412,18 @@ class BarManager:
 			spads.slog("Unhandled exception: " + str(sys.exc_info()[0]) + "\n" + str(traceback.format_exc()), 0)
 
 	def onPrivateMsg(self, userName, message):
-		# todo: nothing yet
-		try:
+		try:			
 			spads.slog("onPrivateMsg: " + str([userName, message]), DBGLEVEL)
+   
+			if userName == 'Coordinator':
+				args = message.split()
+				command = args.pop(0)
+				onTeiServerMessage(command, args)
 
 		except Exception as e:
 			spads.slog("Unhandled exception: " + str(sys.exc_info()[0]) + "\n" + str(traceback.format_exc()), 0)
 		return 0  # return 1 if dont want Spads core to parse this message
-
+        
 	def onVoteRequest(self, source, user, command, remainingVoters):
 		# $source indicates the way the vote has been requested ("pv": private lobby message, "battle": battle lobby message, "chan": master lobby channel message, "game": in game message)
 		# $user is the name of the user requesting the vote


### PR DESCRIPTION
SPADS `onPrivateMsg` handler will now scan for username called `Coordinator` (aka Teiserver)

if such user is messaging it will read the message and split with spaces to make array
the first array element is the command and the rest are arguments

additionally implemented a updateSkill handler, that hopefully parses additional player list and pokes SPADS to update their skill. 

To update the skill ratings the Teiserver should send a message to SPADS:
sample:
`updateSkill [DE]LSR Teifion Flash deltars`
