### PR TITLE
!nextmap rotation update

### DIFF
--- a/etc/mapLists.conf
+++ b/etc/mapLists.conf
@@ -748,7 +748,6 @@ Stronghold V4
 Tau12
 Tempest_V3
 TheRock_V3
-TMA20X 1.8
 Tundra Continents v2.3
 Twin Lakes Park Redux 1.2
 


### PR DESCRIPTION
Removes TMA20X 1.8 from the 8v8 map rotation (it was there on accident).