### PR TITLE
reCallVoteDelay from 10 to 30

### DIFF
--- a/etc/spads.conf
+++ b/etc/spads.conf
@@ -58,7 +58,7 @@ msgFloodAutoKick:15;7
 statusFloodAutoKick:24;8
 kickFloodAutoBan:5;120;5
 cmdFloodAutoIgnore:8;8;4
-reCallVoteDelay:10
+reCallVoteDelay:100
 floodImmuneLevel:100
 
 # Logging system

--- a/etc/spads.conf
+++ b/etc/spads.conf
@@ -58,7 +58,7 @@ msgFloodAutoKick:15;7
 statusFloodAutoKick:24;8
 kickFloodAutoBan:5;120;5
 cmdFloodAutoIgnore:8;8;4
-reCallVoteDelay:100
+reCallVoteDelay:30
 floodImmuneLevel:100
 
 # Logging system


### PR DESCRIPTION
> When a vote ends, SPADS prevents the user who started the vote to call another vote too fast, so that other users have some time to call a vote if they want to (vote flood protection). This is the minimum delay in seconds before someone can call another vote when his previous vote ended.

This change should hopefully reduce vote spam per user.