### PR TITLE
send chobby state whenever a player joins

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -775,6 +775,8 @@ def hJOINEDBATTLE(command, battleID, userName, battlestatus=0):
 def h_autohost_PLAYER_JOINED(command, playerNumInt, userName):
 	global hwInfoIngame
 	try:
+		SendChobbyState()
+		
 		#spads.slog("h_autohost_PLAYER_JOINED:" + str([command, playerNumInt, userName]),3)
 		if playerNumInt in hwInfoIngame:
 			hwInfoIngame[playerNumInt]['username'] = userName


### PR DESCRIPTION
Lobby should be told of all the SPADS settings up front when a player joins a battle