### PR TITLE
Bump minVoteParticipation from 50 to 100 for team resign and stop command

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -201,7 +201,7 @@ battle,pv:player,spec:stopped|110:10
 battle,pv:player:stopped|100:10
 ::|100:
 
-[resign](voteTime:60,majorityVoteMargin:25)
+[resign](voteTime:60,majorityVoteMargin:25,minVoteParticipation:100)
 :playing:running|110:0
 ::running|100:
 

--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -242,7 +242,7 @@ battle,pv:player:stopped|100:10
 [status]
 ::|0:
 
-[stop]
+[stop](minVoteParticipation:100)
 battle,pv,game:playing:|100:0
 ::|100:
 


### PR DESCRIPTION
This change updates away-mode, "!vote b" votes or abstaining votes to effectively count as a "no" vote. 

The currently used `minVoteParticipation:50` value is set globally in `etc/spads.conf` and is being overriden only for the `!resign` command.

Currently, the following situation can occur and result in a successful team resign vote:
- 8 players
- 4 yes votes
- 1 no vote
- 3 abstained votes

Effectively 50% of the eligible voters can end the game.

With this change implemented, a 75% majority of explicit yes votes from the total eligible voters will be required for the vote to succeed.

Discussion & Context can be found [here](https://discord.com/channels/549281623154229250/1223834837727838299).

--- 

Applied the same change to the `!stop` command as well after a short discussion about it in Discord. The impact here is slightly different as the eligible voter base is covering both teams. There is no `majorityVoteMargin` override set for the `!stop` command, so 50% explicit yes votes are still enough for it to succeed. This could potentially be updated in the future to have a  `majorityVoteMargin:25` added as well.
