### PR TITLE
Prevent certain unilateral boss votes during running games.

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -243,8 +243,8 @@ battle,pv:player:stopped|100:10
 ::|0:
 
 [stop](minVoteParticipation:100)
-battle,pv,game:playing:|100:0
-::|100:
+battle,pv,game:playing:|110:0
+::|110:
 
 [teamSize]
 battle,pv:player:stopped|100:10

--- a/etc/commands_custom.conf
+++ b/etc/commands_custom.conf
@@ -41,24 +41,27 @@ battle:player,playing:|100:10
 ::|130:
 
 [bKick]
-battle,pv,game:player:|100:10
-::|100:
+battle,pv,game:player:running|110:0
+battle,pv,game:player:stopped|100:0
+::|110:
 
 [bSet]
 battle,pv:player:stopped|100:10
 ::|100:
 
 [gKick]
-battle,pv,game:player:running|100:10
-::running|100:
+battle,pv,game:player:running|110:0
+::running|110:
 
 [kick]
-battle,pv,game:player:|100:10
-::|100:
+battle,pv,game:player:running|110:0
+battle,pv,game:player:stopped|100:0
+::|110:
 
 [kickBan]
-battle,pv,game:player:|100:10
-::|100:
+battle,pv,game:player:running|110:0
+battle,pv,game:player:stopped|100:0
+::|110:
 
 [set]
 :player:|100:10


### PR DESCRIPTION
Update access requirements for !stop, !gKick, !gKick, !kick, and !kickBan commands while a game is running.

With the new access requirements, bosses are no longer able to unilaterally use those commands mid-game. Instead, a vote begins when a boss attempts to use them.

As a side effect, non-boss players in a boss-lobby are also able to initiate votes for the listed commands. This is necessary in-game, because otherwise only the boss would be eligible to vote.

It is not strictly necessary to allow non-boss votes when no game is running, but for consistency reasons this PR does allow that (as it doesn't make much sense to allow users to vote in game but not in lobby).
