### PR TITLE
Make all remaining boss-only $-commands votable (as !-commands).

### DIFF
--- a/etc/BarManagerCmd.conf
+++ b/etc/BarManagerCmd.conf
@@ -77,3 +77,15 @@ battle:player,playing:|100:10
 [welcome-message]
 battle:player,playing:|100:10
 ::|100:100
+
+[gatekeeper](voteTime:60,majorityVoteMargin:25)
+battle:player,playing:|100:10
+::|100:100
+
+[meme]
+battle:player,playing:|100:10
+::|100:100
+
+[balancealgorithm]
+battle:player,playing:|100:10
+::|100:100

--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -34,3 +34,35 @@
 
 [welcome-message]
 !welcome-message [message] Sets the welcome message sent to anybody joining the lobby. Run this command without a message to clear the existing message. Use $$ to add a line return.
+
+[gatekeeper]
+!gatekeeper <restriction> - Sets the gatekeeper for this battle.
+"!gatekeeper default": No limitations
+"!gatekeeper friends": Allows only friends of existing members to join the lobby
+"!gatekeeper friendsplay": Allows only friends of existing players to become players (but anybody can join to spectate)
+
+[meme]
+!meme <meme> - A predefined bunch of settings for meme games. It's all Rikerss' fault.
+"!meme undo": Removes all meme effects
+"!meme ticks": Ticks only, don't go Cortex!
+"!meme nodefence": No defences
+"!meme nodefence2": No defence meme, No LLTs ver
+"!meme greenfields": No metal extractors
+"!meme rich": Infinite money
+"!meme poor": No money generation
+"!meme hardt1": T1 but no seaplanes or hovers either
+"!meme crazy": Random combination of several settings
+"!meme deathmatch": Start with 35k metal and 1k energy. Everything builds fast, runs fast, and hits hard. Anti-nukes are disabled.
+"!meme noscout": No scout, radar, or spy units
+"!meme hoversonly": Limited to hovers only, including your commander
+"!meme nofusion": No T2 Fusion Energy production
+"!meme armonly": A fight of Technological Supremacy upon you
+"!meme coronly": May pure Brute Strength grant you Honour in battle
+"!meme legonly": Scorched Earth be upon us all
+"!meme armvcor": Armada vs Cortex (+vs legion if enabled) mode
+
+[balancealgorithm]
+!balancealgorithm <algorithm> - Sets the balance algorithm used to autobalance the teams.
+"!balancealgorithm cheeky_switcher_smart"
+"!balancealgorithm loser_picks"
+"!balancealgorithm split_one_chevs"

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -385,6 +385,11 @@ class BarManager:
         spads.addSpadsCommandHandler({'resetchevlevels': getTeiserverNoParameterCommandHandler("resetchevlevels")})
         spads.addSpadsCommandHandler({'rename': getTeiserverStringCommandHandler("rename", re.compile("^[a-zA-Z0-9_\\-\\[\\] \\<\\>\\+\\|:]+$"))})
         spads.addSpadsCommandHandler({'welcome-message': getTeiserverStringCommandHandler("welcome-message", re.compile("^.*$"))})
+        spads.addSpadsCommandHandler({'gatekeeper': getTeiserverStringCommandHandler("gatekeeper", re.compile("^(friends|friendsplay|default)$"))})
+        spads.addSpadsCommandHandler({'meme': getTeiserverStringCommandHandler("meme",
+            re.compile("^(undo|ticks|nodefence|nodefence2|greenfields|rich|poor|hardt1|crazy|deathmatch|noscout|hoversonly|nofusion|armonly|coronly|legonly|armvcor)$"))})
+        spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancemode",
+            re.compile("^(cheeky_switcher_smart|loser_picks|split_one_chevs)$"))})
 
         # We need to add the lobby command handlers before we are fully connected, or we dont get the JOINEDBATTLE stuff
         # These will get replaced automatically when connect again
@@ -1195,7 +1200,7 @@ def getTeiserverStringCommandHandler(cmd, validRegex):
 
             if not validRegex.search(combinedParams):
                 spads.slog(cmd + ": syntax error: regex did not match", DBGLEVEL)
-                spads.sayPrivate(user, cmd + ": Contains forbidden characters.")
+                spads.sayPrivate(user, cmd + ": Invalid parameters, check the help entry for advice: \"!help " + cmd + "\"")
                 return False
 
             # All parameter checking was successful, return now if no action is desired


### PR DESCRIPTION
Add !gatekeeper, !meme, and !balancealgorithm commands.

Note: "!balancealgorithm" is equivalent to "$balancemode". A new name was needed because there is an existing "!balancemode" command in SPADS, with a different purpose.

With this PR, all $-commands which require boss privileges should now have votable !-command versions.