### PR TITLE
Prevent electing bosses for lobbies with more than one player.

### DIFF
--- a/etc/commands_custom.conf
+++ b/etc/commands_custom.conf
@@ -38,6 +38,7 @@
 
 [boss](voteTime:60,majorityVoteMargin:25)
 battle:player,playing:|100:10
+battle:spec:|100:
 ::|130:
 
 [bKick]

--- a/etc/commands_default.conf
+++ b/etc/commands_default.conf
@@ -38,6 +38,7 @@
 
 [boss](voteTime:60,majorityVoteMargin:25)
 battle:player,playing:|100:0
+battle:spec:|100:
 ::|130:
 
 [bKick]

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -787,6 +787,21 @@ class BarManager:
         try:
             spads.slog("preSpadsCommand: " + ','.join(map(str,
                        [command, source, user, params])), DBGLEVEL)
+
+            # We check "len(params) > 1" here so that only commands like "callvote boss UserName"
+            # are considered, and commands like "callvote boss" are allowed.
+            if command == "callvote" and len(params) > 1 and params[0] == "boss":
+                battle = spads.getLobbyInterface().getBattle()
+                numPlayers = sum(1 for u in battle['users'].values() if u['battleStatus']['mode'] == 1)
+                accessLevel = 0
+                try:
+                    accessLevel = int(spads.getUserAccessLevel(user))
+                except TypeError:
+                    pass
+                if numPlayers > 1 and accessLevel < 100:
+                    spads.sayBattle(user + ", you are not allowed to call command \"callvote boss\" in current context (there is more than one player in the lobby)")
+                    return 0
+
         except Exception as e:
             spads.slog("Unhandled exception: " + str(sys.exc_info()
                        [0]) + "\n" + str(traceback.format_exc()), 0)


### PR DESCRIPTION
### **This PR is a significant change to player-facing functionality, and should not be deployed without an accompanying announcement!**
_(I'll write up a proposed announcement tomorrow, but this can be reviewed for now at least)_
_(Also, https://github.com/beyond-all-reason/teiserver/pull/382 and https://github.com/beyond-all-reason/spads_config_bar/pull/137 should be merged/deployed before this PR)_

This patch makes two changes:

First, logic is added to `preSpadsCommand()` which blocks commands of the form "!callvote boss USERNAME" when:
- There is more than one **player** in the lobby
- AND, the caller has accessLevel < 100 (not a boss/mod/admin)

(Note that SPADS implicitly converts "!boss ..." to "!callvote boss ..." when the caller is low-privileged.)

Second, spectators with accessLevel 100 (already a boss) are permitted to use the "!boss" command. This makes it more convenient to transfer boss privileges to another player.