### PR TITLE
Add "!setratinglevels" command.

### DIFF
--- a/etc/BarManagerCmd.conf
+++ b/etc/BarManagerCmd.conf
@@ -70,6 +70,10 @@ battle:player,playing:|100:10
 battle:player,playing:|100:10
 ::|100:100
 
+[setratinglevels](voteTime:60,majorityVoteMargin:25)
+battle:player,playing:|100:10
+::|100:100
+
 [rename]
 battle:player,playing:|100:10
 ::|100:100

--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -29,6 +29,9 @@
 [resetchevlevels]
 !resetchevlevels - removes the minimum/maximum rank requirements
 
+[resetratinglevels]
+!setratinglevels <min-rating> <max-rating> - Sets the minimum and maximum rating levels for players.
+
 [rename]
 !rename <name> - Renames the lobby to the given name.
 

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -1234,17 +1234,10 @@ def setRatingLevelsCommandHandler(source, user, params, checkOnly):
         # All parameter checking was successful, return now if no action is desired
         if checkOnly:
             return True
-
-        if newMinValue < 0:
-            newMinValue = 0
-        if newMinValue > 999:
-            newMinValue = 999
-        if newMaxValue < 1:
-            newMaxValue = 1
-        if newMaxValue > 1000:
-            newMaxValue = 1000
-        if newMaxValue <= newMinValue:
-            newMaxValue = newMinValue + 1
+		
+	#Clamp new rating values within sane ranges and insure a non-empty range
+	newMinValue = min(999,  max(0,               newMinValue))
+	newMaxValue = min(1000, max(newMinValue + 1, newMaxValue))
 
         spads.queueLobbyCommand(["SAYBATTLE", "$%setratinglevels " + str(newMinValue) + " " + str(newMaxValue)])
     except Exception as e:


### PR DESCRIPTION
Add a votable !-command version of the existing "$setratinglevels" command from Teiserver.

(Somehow I managed to miss this one, when I was making my list of $-commands to work on...)

The following commands were tested with this change in place, and I confirmed that the expected result occurred for each (either syntax error or clamping+applying the requested limits):
```
!setratinglevels 10 20
!setratinglevels 1 1
!setratinglevels 0 0
!setratinglevels 1000 1000
!setratinglevels 50 50
!setratinglevels 50 0
!setratinglevels 10 0
!setratinglevels 0 10
!setratinglevels 999 0
!setratinglevels 1000 0
!setratinglevels 9999 9999
!setratinglevels a a
!setratinglevels a 1
!setratinglevels 1 a
!setratinglevels 1 1 1
!setratinglevels
!setratinglevels a
!setratinglevels 1
```