### PR TITLE
Set empty teaser for private lobbies

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -155,15 +155,11 @@ def sendTachyonBattleTeaser():
     global TachyonBattle, myBattlePassword, myBattleTeaser, whoIsBoss
     try:
         # ok, what should our teaser look like?
-        # TachyonBattle = {"boss":"", 'preset':"", 'botlist' : [], 'teamSize' : 6, 'nbTeams':2}
-        # TODO: dont forget to reset the title when the last player leaves!
-        # TODO: dont do this for private games
-        if myBattlePassword != "*":
-            spads.slog(
-                "myBattlePassword being set prevents title change:" + myBattlePassword, DBGLEVEL)
-            return
         newbattleteaser = ""
-        if len(playersInMyBattle) != 0:
+        # We'll use the default (blank) Teaser for private and empty lobbies
+        # Otherwise, build a Teaser based on the lobby's current settings
+        if myBattlePassword == "*" and len(playersInMyBattle) != 0:
+            # TachyonBattle = {"boss":"", 'preset':"", 'botlist' : [], 'teamSize' : 6, 'nbTeams':2}
             # "botlist": ["SimpleDefenderAI", "NullAI", "BARb", "SimpleAI", "SimpleConstructorAI", "ScavengersAI", "SimpleCheaterAI", "ControlModeAI", "STAI", "ChickensAI"]}"
             bottypes = []
             botlist = TachyonBattle["botlist"]

--- a/var/plugins/ratingmanager.py
+++ b/var/plugins/ratingmanager.py
@@ -23,6 +23,21 @@ def getRequiredSpadsVersion(pluginName):
     return requiredSpadsVersion
 
 
+def getBarGameType(teamsize, teamcount):
+    if teamcount <= 2:
+        if teamsize == 1:
+            return "Duel"
+        elif teamsize <= 5:
+            return "Small Team"
+        else:
+            return "Large Team"
+    else:
+        if teamsize == 1:
+            return "FFA"
+        else:
+            return "Team FFA"
+
+
 class RatingManager:
     def __init__(self, context):
         global server_url, rating_url, balance_url
@@ -43,7 +58,13 @@ class RatingManager:
     def updatePlayerSkill(self, playerSkill, accountId, modName, gameType):
         try:
             raw_data = ""
-            with urllib.request.urlopen(f"{rating_url}/{accountId}/{gameType}") as f:
+            spadsConf = spads.getSpadsConf()
+            teamsize = spadsConf["teamSize"]
+            teamcount = spadsConf["nbTeams"]
+            barGameType = getBarGameType(teamsize, teamcount)
+            barGameType = barGameType.replace(" ", "%20")
+
+            with urllib.request.urlopen(f"{rating_url}/{accountId}/{barGameType}") as f:
                 raw_data = f.read().decode('utf-8')
                 data = json.loads(raw_data)
 


### PR DESCRIPTION
Currently, sendTachyonBattleTeaser() returns early if the lobby has a password set. With this change, an empty string is used as the Teaser instead.

This change is intended to make the function more robust; if a Teaser happens to be set when it shouldn't be, then the function now has a way to correct that.