### PR TITLE
Update teaser on first player join

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -1341,6 +1341,8 @@ def hJOINEDBATTLE(command, battleID, userName, battleStatus=0):
             SendChobbyState()
             playersInMyBattle[userName] = battleStatus
             sendCurrentVote()
+            if len(playersInMyBattle) == 1:  # when the first person joins, set teaser
+                sendTachyonBattleTeaser()
             # spads.queueLobbyCommand(["SAYBATTLEEX", "hello dude"])
     except Exception as e:
         spads.slog("Unhandled exception: " + str(sys.exc_info()

--- a/var/plugins/ratingmanager.py
+++ b/var/plugins/ratingmanager.py
@@ -23,6 +23,21 @@ def getRequiredSpadsVersion(pluginName):
     return requiredSpadsVersion
 
 
+def getBarGameType(teamsize, teamcount):
+    if teamcount <= 2:
+        if teamsize == 1:
+            return "Duel"
+        elif teamsize <= 5:
+            return "Small Team"
+        else:
+            return "Large Team"
+    else:
+        if teamsize == 1:
+            return "FFA"
+        else:
+            return "Team FFA"
+
+
 class RatingManager:
     def __init__(self, context):
         global server_url, rating_url, balance_url
@@ -43,7 +58,13 @@ class RatingManager:
     def updatePlayerSkill(self, playerSkill, accountId, modName, gameType):
         try:
             raw_data = ""
-            with urllib.request.urlopen(f"{rating_url}/{accountId}/{gameType}") as f:
+            spadsConf = spads.getSpadsConf()
+            teamsize = spadsConf["teamSize"]
+            teamcount = spadsConf["nbTeams"]
+            barGameType = getBarGameType(teamsize, teamcount)
+            barGameType = barGameType.replace(" ", "%20")
+
+            with urllib.request.urlopen(f"{rating_url}/{accountId}/{barGameType}") as f:
                 raw_data = f.read().decode('utf-8')
                 data = json.loads(raw_data)
 


### PR DESCRIPTION
BarManager removes the Teaser when the last player leaves a lobby.

But, currently it does not have a corresponding check for whether a Teaser should be set when a first player joins the lobby. This patch adds such a check; this makes it so that the Teaser will be updated quickly (before a configuration change is made).