### PR TITLE
Completely remove "Boss:" from Teasers, and hide preset when sane.

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -153,11 +153,6 @@ def refreshChobbyState():
 def buildBattleTeaser():
     global TachyonBattle, whoIsBoss
 
-    
-
-    if whoIsBoss is not None:
-        return ' | Boss: ' + str(whoIsBoss)
-
     bottype = None
     botlist = TachyonBattle["botlist"]
     if len(botlist) > 0:
@@ -168,49 +163,36 @@ def buildBattleTeaser():
         else:
             bottype = "AI"
 
-    if TachyonBattle['preset'] == 'ffa':
-        newbattleteaser = " | FFA"
-        if bottype is not None:
-            newbattleteaser += " vs " + bottype
-        return newbattleteaser
-
-    elif TachyonBattle['preset'] == 'duel':
-        newbattleteaser = " | Duel"
-        if bottype is not None:
-            newbattleteaser += " vs " + bottype
-        return newbattleteaser
-
-    elif TachyonBattle['preset'] == 'team':
-        newbattleteaser = " | Team"
-        if bottype is not None:
-            newbattleteaser += " vs " + bottype
-        else:
-            newbattleteaser += ' ' + \
-                'v'.join([str(TachyonBattle['teamSize'])]
-                            * int(TachyonBattle['nbTeams']))
-        return newbattleteaser
-
-    elif TachyonBattle['preset'] == 'draft':
-        return " | Captains " + \
+    if bottype is not None:
+        if TachyonBattle['preset'] == 'ffa':
+            return " | FFA vs " + bottype
+        elif TachyonBattle['preset'] == 'duel':
+            return " | Duel vs " + bottype
+        elif TachyonBattle['preset'] == 'team':
+            return " | Team vs " + bottype
+        elif TachyonBattle['preset'] == 'tourney':
+            return " | Tourney"
+        elif TachyonBattle['preset'] == 'coop':
+            return " | Coop vs " + bottype
+        elif TachyonBattle['preset'] == 'custom':
+            return " | Custom vs " + bottype
+    else:
+        if TachyonBattle['preset'] == 'ffa':
+            return " | FFA"
+        elif TachyonBattle['preset'] == 'duel':
+            return " | Duel"
+        elif TachyonBattle['preset'] == 'team':
+            return " | " + \
             'v'.join([str(TachyonBattle['teamSize'])]
                     * int(TachyonBattle['nbTeams']))
-
-    elif TachyonBattle['preset'] == 'tourney':
-        return " | Tourney"
-
-    elif TachyonBattle['preset'] == 'coop':
-        newbattleteaser = " | Coop"
-        if bottype is not None:
-            newbattleteaser += " vs " + bottype
-        return newbattleteaser
-
-    elif TachyonBattle['preset'] == 'custom':
-        if bottype is not None:
-            return " | Custom vs " + bottype
-        else:
-            return ' | Custom ' + \
-                'v'.join([str(TachyonBattle['teamSize'])]
-                            * int(TachyonBattle['nbTeams']))
+        elif TachyonBattle['preset'] == 'tourney':
+            return " | Tourney"
+        elif TachyonBattle['preset'] == 'coop':
+            return " | Coop"
+        elif TachyonBattle['preset'] == 'custom':
+            return " | " + \
+            'v'.join([str(TachyonBattle['teamSize'])]
+                    * int(TachyonBattle['nbTeams']))
 
 def sendTachyonBattleTeaser():
     global myBattlePassword, myBattleTeaser


### PR DESCRIPTION
More changes arising from #142

Previously, a "Boss:" Teaser would conditionally be used. With this
patch, the "Boss:" entry is never included in the Teaser.

Additionally, when the "Team" and "Custom" presets are in use (and
there are no bots), the name of the preset is not displayed. For
example:

Before change: ` | Team 8v8`
After change:  ` | 8v8`

Before change: ` | Custom 4v4v4v4`
After change: ` | 4v4v4v4`

This does not apply when bots are configured. In such cases, the
preset name is still included (same behavior as before). For
example:

- ` | Team vs Scavengers`
- ` | Custom vs Raptors`
- ` | Coop vs AI`