### PR TITLE
Allow custom preset boss to take breaks

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -47,7 +47,7 @@ battle,pv:player:stopped|90:10
 ::|100:
 
 [balance]
-battle,pv:player:stopped|10:10
+battle,pv:player:stopped|0:0
 ::|100:
 
 [auth]
@@ -235,6 +235,11 @@ battle,pv,game:player,spec:|0:
 [split]
 battle,pv:player:stopped|100:10
 ::|100:
+
+[start]
+battle,pv:player:stopped|100:0
+::stopped|100:
+battle:spec:stopped|100:100
 
 [stats]
 ::|0:

--- a/etc/commands_custom.conf
+++ b/etc/commands_custom.conf
@@ -36,10 +36,6 @@
 #
 ################################################################################
 
-[balance]
-battle,pv:player:stopped|0:0
-::|100:
-
 [boss](voteTime:60,majorityVoteMargin:25)
 battle:player,playing:|100:10
 battle:spec:|100:
@@ -76,8 +72,3 @@ battle:spectator:|100:100
 [specAfk]
 battle,pv:player:stopped|100:10
 ::|100:
-
-[start]
-battle,pv:player:stopped|100:0
-::stopped|100:
-battle:spec:stopped|100:100

--- a/etc/commands_custom.conf
+++ b/etc/commands_custom.conf
@@ -36,6 +36,10 @@
 #
 ################################################################################
 
+[balance]
+battle,pv:player:stopped|0:0
+::|100:
+
 [boss](voteTime:60,majorityVoteMargin:25)
 battle:player,playing:|100:10
 battle:spec:|100:
@@ -74,6 +78,6 @@ battle,pv:player:stopped|100:10
 ::|100:
 
 [start]
-battle,pv:player:stopped|100:10
+battle,pv:player:stopped|100:0
 ::stopped|100:
 battle:spec:stopped|100:100

--- a/etc/commands_default.conf
+++ b/etc/commands_default.conf
@@ -69,8 +69,3 @@ battle:spectator:|100:100
 [specAfk]
 battle,pv:player:stopped|100:0
 ::|100:
-
-[start]
-battle,pv:player:stopped|100:0
-::stopped|100:
-battle:spec:stopped|100:100


### PR DESCRIPTION
The purpose of this PR is allow a custom preset boss to take breaks. With these changes, players can vote to start and can also balance (without vote).

Mostly fixes #134

Allowing force speccing can be a separate PR since it's non trivial.
