### PR TITLE
Minor boss changes

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -816,7 +816,7 @@ class BarManager:
 
             # We check "len(params) > 1" here so that only commands like "callvote boss UserName"
             # are considered, and commands like "callvote boss" are allowed.
-            if command == "callvote" and len(params) > 1 and params[0] == "boss":
+            if command == "callvote" and len(params) > 1 and params[0] == "boss" and myBattlePassword == "*":
                 battle = spads.getLobbyInterface().getBattle()
                 numPlayers = sum(1 for u in battle['users'].values() if u['battleStatus']['mode'] == 1)
                 accessLevel = 0

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -151,7 +151,7 @@ def refreshChobbyState():
     SendChobbyState()
 
 def buildBattleTeaser():
-    global TachyonBattle, whoIsBoss
+    global TachyonBattle
 
     bottype = None
     botlist = TachyonBattle["botlist"]
@@ -921,7 +921,6 @@ class BarManager:
         return
 
     def changeUserAccessLevel(self, userName, userData, isAuthenticated, currentAccessLevel):
-        global whoIsBoss
         #  updateStatusInfo: params={'Name': '[teh]behetest', 'Skill': '[16.67 ???]', 'ID': '3726', 'Rank': 2},3726,Beyond All Reason test-24450-6c81e38,Duel,30
 
         try:
@@ -1274,8 +1273,8 @@ def setRatingLevelsCommandHandler(source, user, params, checkOnly):
         # All parameter checking was successful, return now if no action is desired
         if checkOnly:
             return True
-		
-	#Clamp new rating values within sane ranges and insure a non-empty range
+
+        #Clamp new rating values within sane ranges and insure a non-empty range
         newMinValue = min(999,  max(0,               newMinValue))
         newMaxValue = min(1000, max(newMinValue + 1, newMaxValue))
 
@@ -1346,9 +1345,18 @@ def hLEFTBATTLE(command, battleID, userName):
                 sendTachyonBattleTeaser()
 
             if whoIsBoss == userName:
+                # Set 'whoIsBoss' to another boss in the lobby, or None if there are no other bosses
                 whoIsBoss = None
-                ChobbyStateChanged("boss", "")
-                updateTachyonBattle("boss", "")
+                bosses = spads.getBosses()
+                if userName in bosses:
+                    del bosses[userName]
+                if len(bosses) > 0:
+                    whoIsBoss = next(iter(bosses.keys()))
+
+                ChobbyStateChanged(
+                    "boss", "" if whoIsBoss is None else whoIsBoss)
+                updateTachyonBattle(
+                    "boss", "" if whoIsBoss is None else whoIsBoss)
     except Exception as e:
         spads.slog("Unhandled exception: " + str(sys.exc_info()
                    [0]) + "\n" + str(traceback.format_exc()), 0)


### PR DESCRIPTION
This PR consists of one bugfix and one minor functional change.
____
Bugfix: In lobbies with multiple bosses, if a specific boss leaves the lobby then the crown is no longer displayed for the remaining bosses. (Note that the remaining bosses do still have boss privileges; this is a cosmetic issue.)

To test this fix, the following steps can be used:
1. USER_A: Join lobby
2. USER_A: Claim boss for self
3. USER_B: Join lobby
4. USER_A: Give boss to USER_B
5. USER_A: Run `!barmanagerprintstate`, observe that `whoIsBoss` = USER_B
6. USER_B: Leave lobby

Result on current code:
- USER_A no longer has a crown (broken)
- `!status` output shows that USER_A is still boss (correct)
- `!barmanagerprintstate` output shows that `whoIsBoss` = None (broken)

Result with this PR:
- USER_A still has a crown (correct)
- `!status` output shows that USER_A is still boss (correct)
- `!barmanagerprintstate` output shows that `whoIsBoss` = USER_A (correct)
____
Functional change:

Private lobbies (i.e. lobbies with a password set) no longer enforce the one-player requirement for `!boss`.