### PR TITLE
Add `!setAllAiBonus` command.

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -229,6 +229,10 @@ battle,pv,game:player,spec:|0:
 [sendLobby]
 ::|130:
 
+[setAllAiBonus]
+battle,pv:player:stopped|100:10
+::|100:
+
 [smurfs]
 ::|110:
 

--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -69,3 +69,8 @@
 "!balancealgorithm cheeky_switcher_smart"
 "!balancealgorithm loser_picks"
 "!balancealgorithm split_one_chevs"
+
+[setAllAiBonus]
+!setAllAiBonus <bonus> - Sets the economic bonus for each AI in the battle. The bonus must be between 0-100.
+"!setAllAiBonus 0"
+"!setAllAiBonus 100"


### PR DESCRIPTION
_Note: Currently marked as a draft, pending testing on the Integration branch. However, the Integration branch appears to have diverged from Main -- could someone please overwrite Integration with a force-push from Main?_
____
Adds a new `!setAllAiBonus <bonus>` command, to allow players to update the economic bonus for all Bot players in one command. This can significantly reduce the number of votes needed in Coop lobbies that do not have a boss.

Ref: https://discord.com/channels/549281623154229250/1272161071951777825