### PR TITLE
Make update script discard all local changes during git updates.

### DIFF
--- a/spads_config_bar_updater.py
+++ b/spads_config_bar_updater.py
@@ -62,8 +62,8 @@ def recursecopy(workdir):
 
 def configupdate(args):
 	if args.nogit != True:
-		execute("git fetch origin")
-		execute("git reset --hard FETCH_HEAD")
+		execute("git fetch origin $(git rev-parse --abbrev-ref HEAD)")
+		execute("git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)")
 		execute("git clean -xfdf")
 	for root, directory, filenames in os.walk("."):
 		goodfile = True

--- a/spads_config_bar_updater.py
+++ b/spads_config_bar_updater.py
@@ -62,7 +62,9 @@ def recursecopy(workdir):
 
 def configupdate(args):
 	if args.nogit != True:
-		execute("git pull https://github.com/beyond-all-reason/spads_config_bar.git")
+		execute("git fetch origin")
+		execute("git reset --hard FETCH_HEAD")
+		execute("git clean -xfdf")
 	for root, directory, filenames in os.walk("."):
 		goodfile = True
 		for ignorefiletype in ignorefiletypes:


### PR DESCRIPTION
Currently, `spads_config_bar_updater.py` executes the following command to fetch updates from this repository:
- `git pull https://github.com/beyond-all-reason/spads_config_bar.git`

However, the above command does not reconcile any divergences between the local and remote repositories. That is fine for how the `main` branch is used, but the `integration` branch frequently diverges from the `main` branch (either due to automatic map metadata updates, or manual rebasing/rewriting).

This patch replaces the above command with the following commands:
- `git fetch origin`: download (but do not merge/checkout) all tracked branches from the remote repo.
- `git reset --hard FETCH_HEAD`: Update git's index *and* the working tree to match the fetched HEAD.
- `git clean -xfdf`: Remove any leftover, untracked files from the working tree.