### PR TITLE
Update deprecated "$balancemode" usage with "$balancealgorithm".

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -406,7 +406,7 @@ class BarManager:
         spads.addSpadsCommandHandler({'gatekeeper': getTeiserverStringCommandHandler("gatekeeper", re.compile("^(friends|friendsplay|default)$"))})
         spads.addSpadsCommandHandler({'meme': getTeiserverStringCommandHandler("meme",
             re.compile("^(undo|ticks|nodefence|nodefence2|greenfields|rich|poor|hardt1|crazy|deathmatch|noscout|hoversonly|nofusion|armonly|coronly|legonly|armvcor)$"))})
-        spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancemode",
+        spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancealgorithm",
             re.compile("^(loser_picks|split_noobs)$"))})
 
         # We need to add the lobby command handlers before we are fully connected, or we dont get the JOINEDBATTLE stuff


### PR DESCRIPTION
The original Teiserver command "$balancemode" was deprecated by commit be5865352bd2880b1507efc5f0b2a961cb9bca0e in the Teiserver repo. This commit migrates BarManager to use "$balancealgorithm" instead.