### PR TITLE
replace loser_picks with default for allowed balance algos

### DIFF
--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -66,7 +66,7 @@
 
 [balancealgorithm]
 !balancealgorithm <algorithm> - Sets the balance algorithm used to autobalance the teams.
-"!balancealgorithm loser_picks"
+"!balancealgorithm default"
 "!balancealgorithm split_noobs"
 
 [setAllAiBonus]

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -407,7 +407,7 @@ class BarManager:
         spads.addSpadsCommandHandler({'meme': getTeiserverStringCommandHandler("meme",
             re.compile("^(undo|ticks|nodefence|nodefence2|greenfields|rich|poor|hardt1|crazy|deathmatch|noscout|hoversonly|nofusion|armonly|coronly|legonly|armvcor)$"))})
         spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancemode",
-            re.compile("^(loser_picks|split_noobs)$"))})
+            re.compile("^(default|split_noobs)$"))})
 
         # We need to add the lobby command handlers before we are fully connected, or we dont get the JOINEDBATTLE stuff
         # These will get replaced automatically when connect again


### PR DESCRIPTION
Teiserver (in prod) now no longer has loser_picks as a choice for balance algorithm. It is now either "default" or "split_noobs". Need to update SPADS too. loser_picks does get called by default algo in certain circumstances.

## Testing
```
!balancealgorithm default
!balancealgorithm split_noobs
```
Ensure both commands work