### PR TITLE
Fix players can call balance when auto balance off and there's a boss

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -47,7 +47,7 @@ battle,pv:player:stopped|90:10
 ::|100:
 
 [balance]
-battle,pv:player:stopped|0:0
+battle,pv:player:stopped|10:10
 ::|100:
 
 [auth]


### PR DESCRIPTION
When auto balance is off, players can still manually press the balance button which is annoying to bosses. In one PR I made it so players can run balance even with boss and not considered this side effect
https://discord.com/channels/549281623154229250/1278491500464050229
https://github.com/beyond-all-reason/spads_config_bar/pull/149/files

If there is a boss and autobalance = advanced (the default), the balance will be called automatically when there is an even number of players. This means it is not necessary for players to call balance even if the boss is taking a break.

This PR reverts the change I made before and makes it so more privilege is required to balance. Setting to 10 means that it can be used in non-bossed lobbies