### PR TITLE
Allow force spec to deal with afk boss

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -104,7 +104,7 @@ battle,pv:player:stopped|10:10
 ::|100:
 
 [force]
-battle,pv:player:stopped|100:10
+battle,pv:player:stopped|100:0
 ::|100:
 
 [forcePreset]


### PR DESCRIPTION
When boss is afk there's no way to deal with afk players. It's also possible the boss is afk and a player. This change allows voting on the force spec command when there's a boss. It does have the downside that there are other force commands that are voteable  such as bonus. But those commands are voteable anyway when there's no boss