### PR TITLE
Add `!unboss` command.

### DIFF
--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -275,6 +275,11 @@ battle,pv,game:player,spec:|100:10
 [unlockSpec]
 pv::|0:
 
+[unboss](voteTime:60,majorityVoteMargin:25)
+battle:player,playing:|100:0
+battle:spec:|100:
+::|130:
+
 [update]
 ::|130:
 

--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -74,3 +74,8 @@
 !setAllAiBonus <bonus> - Sets the economic bonus for each AI in the battle. The bonus must be between 0-100.
 "!setAllAiBonus 0"
 "!setAllAiBonus 100"
+
+[unboss]
+!unboss <*|username> - Disables boss mode, either for all players (with '*') or for a single player (with a username).
+"!unboss *"
+"!unboss UserToUnboss"


### PR DESCRIPTION
Add a new `!unboss` command, which:
- Allows players to remove an individual boss in multi-boss lobbies (in the form `!unboss NameOfUser`)
- Allows players to remove all bosses at once (in the form `!unboss *`, similar to the current behavior of `!boss`)
- Has an instructional error message when run without parameters (to avoid the pitfall for `!boss`, where users often thought that running that command without parameters would only unboss themself and not other bosses)

This patch specifically *does not* change the behavior of the `!boss` command (without parameters). Once Chobby has been updated to send `!unboss USERNAME` instead of `!boss`, a new patch can be applied to disable `!boss` (without parameters) with an instructional message.

As discussed in https://discord.com/channels/549281623154229250/1271209857881735179