### PR TITLE
Miscellaneous cleanups/fixes

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -1190,7 +1190,7 @@ def hUnboss(source, user, params, checkOnly):
         if params[0] == '*':
             callPerlFunction("hBoss", "battle", user, [], False) # Just use the SPADS handler
         else:
-            perl.eval("delete %::bosses{" + params[0] + "};")
+            perl.eval("delete $::bosses{" + params[0] + "};")
             spads.broadcastMsg("Boss mode disabled for %s (by %s)" % (params[0], user))
 
         newBosses = "" + ','.join(spads.getBosses())


### PR DESCRIPTION
Various small changes:
- Use the response functions provided by the SPADS API, rather than custom responses via `sayBattle` and friends.
- Add `fix_string` calls for parameters in `hUnboss`, which were left out of the original patch.
- Remove the unused/stub `!myCommand` and `!splitbattle` command handlers (these had no entries in `commands.conf`, and so were inaccessible anyway)
- Update the syntax of the perl code from `hUnboss`, to match the more common/standard way of accomplishing the same goal