### PR TITLE
update `tourney` preset settings

### DIFF
--- a/etc/battlePresets.conf
+++ b/etc/battlePresets.conf
@@ -87,11 +87,12 @@ disabledunits:-*
 startpostype:1|0|2
 
 [tourney] 
-description:Tournament 1v1 Game Battle Settings
+description:Tournament Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:2|0|1
 allowuserwidgets:0
+ranked_game:0
 
 [disablet2]
 description:Disable T2 Factories

--- a/etc/latest_engine_spads.conf
+++ b/etc/latest_engine_spads.conf
@@ -252,12 +252,11 @@ teamSize:1
 autoStart:off
 
 [tourney]
-description:Tournament 1v1 Game Global Settings
+description:Tournament Game Global Settings
 battlePreset:tourney
-autoBalance:on
+autoBalance:off
 nbTeams:2
 nbPlayerById:1
-teamSize:1
 #noSpecChat:1
 autoStart:off
 #mapList:tourney

--- a/etc/spads_cluster.conf
+++ b/etc/spads_cluster.conf
@@ -260,12 +260,11 @@ teamSize:1
 autoStart:off
 
 [tourney]
-description:Tournament 1v1 Game Global Settings
+description:Tournament Game Global Settings
 battlePreset:tourney
-autoBalance:on
+autoBalance:off
 nbTeams:2
 nbPlayerById:1
-teamSize:1
 #noSpecChat:1
 autoStart:off
 #mapList:tourney


### PR DESCRIPTION
Nowadays:

- Tournaments are not 1v1 only, so we remove the `teamSize` enforcement and turn off `autoBalance` to allow for an easier time for team games.
- We now have the technology to disable ranking in tournaments by enforcing the `ranked_game` `bSet` option.