### PR TITLE
Remove outdated `!meme` options to match Teiserver.

### DIFF
--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -48,21 +48,10 @@
 !meme <meme> - A predefined bunch of settings for meme games. It's all Rikerss' fault.
 "!meme undo": Removes all meme effects
 "!meme ticks": Ticks only, don't go Cortex!
-"!meme nodefence": No defences
-"!meme nodefence2": No defence meme, No LLTs ver
-"!meme greenfields": No metal extractors
 "!meme rich": Infinite money
 "!meme poor": No money generation
-"!meme hardt1": T1 but no seaplanes or hovers either
 "!meme crazy": Random combination of several settings
 "!meme deathmatch": Start with 35k metal and 1k energy. Everything builds fast, runs fast, and hits hard. Anti-nukes are disabled.
-"!meme noscout": No scout, radar, or spy units
-"!meme hoversonly": Limited to hovers only, including your commander
-"!meme nofusion": No T2 Fusion Energy production
-"!meme armonly": A fight of Technological Supremacy upon you
-"!meme coronly": May pure Brute Strength grant you Honour in battle
-"!meme legonly": Scorched Earth be upon us all
-"!meme armvcor": Armada vs Cortex (+vs legion if enabled) mode
 
 [balancealgorithm]
 !balancealgorithm <algorithm> - Sets the balance algorithm used to autobalance the teams.

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -431,7 +431,7 @@ class BarManager:
         spads.addSpadsCommandHandler({'welcome-message': getTeiserverStringCommandHandler("welcome-message", re.compile("^.*$"))})
         spads.addSpadsCommandHandler({'gatekeeper': getTeiserverStringCommandHandler("gatekeeper", re.compile("^(friends|friendsplay|default)$"))})
         spads.addSpadsCommandHandler({'meme': getTeiserverStringCommandHandler("meme",
-            re.compile("^(undo|ticks|nodefence|nodefence2|greenfields|rich|poor|hardt1|crazy|deathmatch|noscout|hoversonly|nofusion|armonly|coronly|legonly|armvcor)$"))})
+            re.compile("^(undo|ticks|rich|poor|crazy|deathmatch)$"))})
         spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancealgorithm",
             re.compile("^(default|split_noobs|auto)$"))})
         spads.addSpadsCommandHandler({'unboss': hUnboss})


### PR DESCRIPTION
This patch brings BarManager in line with https://github.com/beyond-all-reason/teiserver/pull/476