### PR TITLE
Add loser picks balance algo

### DIFF
--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -58,6 +58,7 @@
 "!balancealgorithm default"
 "!balancealgorithm split_noobs"
 "!balancealgorithm auto"
+"!balancealgorithm loser_picks"
 
 [setAllAiBonus]
 !setAllAiBonus <bonus> - Sets the economic bonus for each AI in the battle. The bonus must be between 0-100.

--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -436,7 +436,7 @@ class BarManager:
         spads.addSpadsCommandHandler({'meme': getTeiserverStringCommandHandler("meme",
             re.compile("^(undo|ticks|rich|poor|crazy|deathmatch)$"))})
         spads.addSpadsCommandHandler({'balancealgorithm': getTeiserverStringCommandHandler("balancealgorithm",
-            re.compile("^(default|split_noobs|auto)$"))})
+            re.compile("^(default|split_noobs|auto|loser_picks)$"))})
         spads.addSpadsCommandHandler({'unboss': hUnboss})
 
         # We need to add the lobby command handlers before we are fully connected, or we dont get the JOINEDBATTLE stuff


### PR DESCRIPTION
This adds balance algorithm loser_picks

Currently you can set this balance algorithm by using !balancealgorithm default
But if the default changes then we you cannot choose loser_picks. This PR allows select loser_picks even if it is no longer default.