### PR TITLE
Fix missing `!help` entries for several BarManager commands.

### DIFF
--- a/etc/BarManagerCmd.conf
+++ b/etc/BarManagerCmd.conf
@@ -93,3 +93,12 @@ battle:player,playing:|100:10
 [balancealgorithm]
 battle:player,playing:|100:10
 ::|100:100
+
+[unboss](voteTime:60,majorityVoteMargin:25)
+battle:player,playing:|100:0
+battle:spec:|100:
+::|130:
+
+[setAllAiBonus]
+battle,pv:player:stopped|100:10
+::|100:

--- a/etc/commands.conf
+++ b/etc/commands.conf
@@ -229,10 +229,6 @@ battle,pv,game:player,spec:|0:
 [sendLobby]
 ::|130:
 
-[setAllAiBonus]
-battle,pv:player:stopped|100:10
-::|100:
-
 [smurfs]
 ::|110:
 
@@ -274,11 +270,6 @@ battle,pv,game:player,spec:|100:10
 
 [unlockSpec]
 pv::|0:
-
-[unboss](voteTime:60,majorityVoteMargin:25)
-battle:player,playing:|100:0
-battle:spec:|100:
-::|130:
 
 [update]
 ::|130:

--- a/var/plugins/BarManagerHelp.dat
+++ b/var/plugins/BarManagerHelp.dat
@@ -29,7 +29,7 @@
 [resetchevlevels]
 !resetchevlevels - removes the minimum/maximum rank requirements
 
-[resetratinglevels]
+[setratinglevels]
 !setratinglevels <min-rating> <max-rating> - Sets the minimum and maximum rating levels for players.
 
 [rename]


### PR DESCRIPTION
This patch allows the `!help` command to show documentation for the following commands:
- `!setAllAiBonus`
- `!unboss`
- `!setratinglevels`

The help entries for the first two of these was missing because the permissions configuration was placed in the global `commands.conf` file, instead of the plugin-specific `BarManagerCmd.conf` file.

The help entry for the last command was missing because of a copy-paste error (`!resetratinglevels` had two help entries, while `!setratinglevels` had none).

Fixes #180.