### PR TITLE
Miscellaneous cleanups/fixes

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -484,11 +484,11 @@ class BarManager:
             spads.slog("Unhandled exception: " + str(sys.exc_info()
                        [0]) + "\n" + str(traceback.format_exc()), 0)
 
-    def onLobbyConnected(self, lobbyInterface):
+    def onLobbyLogin(self, lobbyInterface):
         try:
             # spads lobby command handlers are unloaded when connection is lost.
             # Thus we need to readd them according to
-            # https://springrts.com/wiki/SPADS_plugin_development_(Python)#Writing_plugin_code_2
+            # https://github.com/Yaribz/SPADS/wiki/SPADS-plugin-development-(Python)#user-content-Writing_plugin_code-2
             self.addLobbyCommandHandlers()
 
         except Exception as e:


### PR DESCRIPTION
Based on a log review by Yaribz, who investigated multiple errors in production SPADS logs for BarManager.

Summary of changes:
- 'getNumUsersInMyBattle()' no longer throws an error when the battle is closed.
- `sendTachyonBattle()` now aborts early if the battle is closed
- Various lobby command handlers now have a more descriptive error message when a precondition is not met
- Lobby command handlers are now registered in an earlier callback, to avoid potentially missing some commands