### PR TITLE
Fix `!unboss` silently failing for usernames containing symbols

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -1218,7 +1218,7 @@ def hUnboss(source, user, params, checkOnly):
         if params[0] == '*':
             callPerlFunction("hBoss", "battle", user, [], False) # Just use the SPADS handler
         else:
-            perl.eval("delete $::bosses{" + params[0] + "};")
+            perl.eval("delete $::bosses{'" + params[0] + "'};")
             spads.broadcastMsg("Boss mode disabled for %s (by %s)" % (params[0], user))
 
         newBosses = "" + ','.join(spads.getBosses())


### PR DESCRIPTION
The Perl code which is currently used to implement the `!unboss` command handler is only valid when the name of the target is alphanumeric.

This patch updates that Perl code, so that it also works when the target's name contains whitelisted symbols.