### PR TITLE
Add 26 map competitive 1v1 pool

### DIFF
--- a/etc/mapLists.conf
+++ b/etc/mapLists.conf
@@ -1222,6 +1222,33 @@ Starwatcher 1.0
 The Tartar Steppe v1.1
 White Fire Remake 1.3
 
+[competitive2p]
+Aurelia v4.1
+Canis River v1.4
+Comet Catcher Remake 1.8
+Crystallized Plains 1.1
+Desolation v1.0.1
+Eye Of Horus 1.7.1
+Fallendell_V4
+Feast of Hades 1.0.1
+Greenhaven BAR v1.2
+Hades Ponds 1.1
+Heartbreak Hill v4.0.1
+Hide and Seek 2.2.3
+Isidis crack 1.1
+Mariposa Island v2.4.1
+Mithril Mountain v2.0.1
+Onyx Cauldron 2.2.1
+Paradise_Lost_V4
+Ravaged Remake v1.2
+Red Comet Remake 1.8
+Sertagatta v6.0.1
+Silent Sea v1.0.1
+Sphagnum Bog v1.2.1
+The Cold Place BAR v1.1
+Theta Crystals 1.3
+Tundra_V2
+
 [testList]
 All That Glitters v2.2
 Altair_Crossing_V4.1


### PR DESCRIPTION
Currently there are 70 maps in the [1v1] pool, and we very rarely use !nextmap because we often get undesirable maps a few in a row, then we give up and manually set a map. The smaller pool will allow 1v1 lobbies to configure auto-rotate should they want to, and help streamline map selection.