### PR TITLE
Update config file with to include a sea map pool for rotation lobbies.

### DIFF
--- a/etc/mapLists.conf
+++ b/etc/mapLists.conf
@@ -1239,6 +1239,29 @@ Flats and Forests v2.2
 Rosetta 1.42
 The Tartar Steppe v1.1
 
+[rotatoSea]
+Azurite Shores 1.01
+Boulder_Beach_V1
+Crescent_Bay_V2
+Deeploria Fields v1.5.1
+Erebos Lakes v1.0
+Failed Negotiations 1.0
+Glacial Gap v1.1
+Hellas Basin v1.4
+Jade Empress 1.41
+Mariposa Island v2.4.1
+Melting Glacier v1.1.1
+Pinch Point 1.03
+Red River Remake v1.2
+Red River Estuary v1.1
+Serene Caldera v1.3
+Tau12
+Tempest_V3
+The BARrier Reef Remake v1.0
+Tropical Assault v3.0
+Tundra Continents v2.3.1
+
+
 [strict]
 Ascendancy v2.2
 Bismuth Valley v2.4.1


### PR DESCRIPTION
This creates a map pool preset for rotation lobbies to play sea maps. It excludes the Supreme for obvious reasons.