### PR TITLE
Add setting date_* modoptions and boss player property

### DIFF
--- a/var/plugins/barmanager.py
+++ b/var/plugins/barmanager.py
@@ -932,6 +932,7 @@ class BarManager:
 		'''
 
         try:
+            res = {}
             spads.slog("addStartScriptTags: " + str(AiProfiles), DBGLEVEL)
             if len(AiProfiles) > 0:
                 extraaitags = {}
@@ -940,7 +941,26 @@ class BarManager:
                     spads.slog("Setting AI profile" +
                                str(extraaitags) + ' for ' + botname, 3)
 
-                return {'aiData': extraaitags}
+                res['aiData'] = extraaitags
+
+            # Set custom user account info property `boss` for all bosses
+            playerData = {}
+            users = spads.getLobbyInterface().getUsers()
+            for boss in spads.getBosses():
+                accountId = users.get(boss, {}).get('accountId')  # it should be always set, but just in case
+                if accountId:
+                    playerData[accountId] = {"boss": 1}
+                pass
+            res['playerData'] = playerData
+
+            # Set current date and time modoptions
+            now = datetime.now(timezone.utc)
+            res['game/modoptions/date_day'] = now.day
+            res['game/modoptions/date_month'] = now.month
+            res['game/modoptions/date_year'] = now.year
+            res['game/modoptions/date_hour'] = now.hour
+
+            return res
         except Exception as e:
             spads.slog("Unhandled exception: " + str(sys.exc_info()
                        [0]) + "\n" + str(traceback.format_exc()), 0)


### PR DESCRIPTION
On game start, plugin will
- set 4 new modoptions that represent current date in UTC timezone: `date_hour`, `date_day`, `date_month`, `date_year`.
- set `boss` custom player property to 1 when player is boss. The custom property of player can be fetched in game using 10th return value from `Spring.GetPlayerInfo` call, similar to `accountid`, like [here](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/1911aedd0a2936bbb4c0eeeeb3e0d78b3868a7eb/luarules/gadgets/api_permissions.lua#L27-L30).

Tested on lobby-server-dev, opened the replay file and the user property and mod options was set properly.