### PR TITLE
Remove delimiters from tweaklava

### DIFF
--- a/etc/battlePresets.conf
+++ b/etc/battlePresets.conf
@@ -27,7 +27,7 @@ tweakunits6:|~[A-Za-z0-9\-\_]*
 tweakunits7:|~[A-Za-z0-9\-\_]*
 tweakunits8:|~[A-Za-z0-9\-\_]*
 tweakunits9:|~[A-Za-z0-9\-\_]*
-map_tweaklava:|0|~/^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$/
+map_tweaklava:|0|~^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$
 
 [ffa] 
 description:FFA Game Battle Settings
@@ -54,7 +54,7 @@ tweakunits6:|~[A-Za-z0-9\-\_]*
 tweakunits7:|~[A-Za-z0-9\-\_]*
 tweakunits8:|~[A-Za-z0-9\-\_]*
 tweakunits9:|~[A-Za-z0-9\-\_]*
-map_tweaklava:|0|~/^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$/
+map_tweaklava:|0|~^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$
 
 [coop] 
 description:Coop PvE Game Battle Settings
@@ -82,7 +82,7 @@ tweakunits6:|~[A-Za-z0-9\-\_]*
 tweakunits7:|~[A-Za-z0-9\-\_]*
 tweakunits8:|~[A-Za-z0-9\-\_]*
 tweakunits9:|~[A-Za-z0-9\-\_]*
-map_tweaklava:|0|~/^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$/
+map_tweaklava:|0|~^(\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})(\s*,\s*\{\s*\d+\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+\s*\})*$
 
 [duel] 
 description:Duel 1v1 Game Battle Settings


### PR DESCRIPTION
Updated regex pattern for map_tweaklava to remove unneeded delimiters.