### PR TITLE
Allow the lobby to set the startbox override modoption

### DIFF
--- a/etc/battlePresets.conf
+++ b/etc/battlePresets.conf
@@ -6,6 +6,7 @@ description:Team Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:2|0|1
+mapmetadata_startbox_override:|~[A-Za-z0-9\-\_]*
 debugcommands:|~.*
 tweakdefs:|~[A-Za-z0-9\-\_]*
 tweakdefs1:|~[A-Za-z0-9\-\_]*
@@ -35,6 +36,7 @@ description:FFA Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:1|0|2
+mapmetadata_startbox_override:|~[A-Za-z0-9\-\_]*
 tweakdefs:|~[A-Za-z0-9\-\_]*
 tweakdefs1:|~[A-Za-z0-9\-\_]*
 tweakdefs2:|~[A-Za-z0-9\-\_]*
@@ -63,6 +65,7 @@ description:Coop PvE Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:2|0|1
+mapmetadata_startbox_override:|~[A-Za-z0-9\-\_]*
 debugcommands:|~.*
 tweakdefs:|~[A-Za-z0-9\-\_]*
 tweakdefs1:|~[A-Za-z0-9\-\_]*
@@ -92,6 +95,7 @@ description:Duel 1v1 Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:1|0|2
+mapmetadata_startbox_override:|~[A-Za-z0-9\-\_]*
 allowuserwidgets:1
 
 [tourney] 
@@ -99,6 +103,7 @@ description:Tournament Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:2|0|1
+mapmetadata_startbox_override:|~[A-Za-z0-9\-\_]*
 allowuserwidgets:0
 ranked_game:0
 allowpausegameplay:0


### PR DESCRIPTION
Declares `mapmetadata_startbox_override` as a settable battle setting in the game battle presets, the same way `tweakdefs`/`tweakunits` already are, so the lobby can push a player's custom start boxes to the game as a modoption.

Part of the polygon startbox work (game beyond-all-reason/Beyond-All-Reason#7513, Chobby beyond-all-reason/BYAR-Chobby#1184). The game prefers a `mapmetadata_startbox_override` whose team count matches over the server-set `mapmetadata_startboxes_set` and the engine start rectangles, so a player's manually-set boxes take precedence over a map's default set. SPADS won't accept a client `!bSet` for a string modoption unless the preset declares it, which is what this adds. The value stays opaque to SPADS - a base64url blob, like the tweak modoptions.

Empty by default, so with no override the game falls back to the set; switching back to the default boxes clears it the same way.

Assisted by Claude Code (Opus 4.8); all code reviewed.
