### PR TITLE
ModeCommand: the !mode plugin

### DIFF
--- a/etc/ModeCommand.conf
+++ b/etc/ModeCommand.conf
@@ -1,0 +1,2 @@
+commandsFile:ModeCommandCmd.conf
+helpFile:ModeCommandHelp.dat

--- a/etc/ModeCommandCmd.conf
+++ b/etc/ModeCommandCmd.conf
@@ -1,0 +1,9 @@
+#?source:status:gameState|directLevel:voteLevel
+
+# !mode is the moded equivalent of the built-in bSet, so it mirrors bSet's
+# privilege exactly: in a stopped battle a player (level >=10) calls a vote and an
+# admin (level >=100) applies directly; elsewhere level 100 with no vote. Keep this
+# in sync with the [bSet] block in SPADS's default commands.conf.
+[mode]
+battle,pv:player:stopped|100:10
+::|100:

--- a/var/plugins/ModeCommandHelp.dat
+++ b/var/plugins/ModeCommandHelp.dat
@@ -1,0 +1,5 @@
+[mode]
+!mode <category> <modeName> [<key1>=<value1> ...] - Apply a gameplay mode with optional customizations
+  Ex: !mode game scavengers scav_difficulty=hard
+  Ex: !mode transfer enabled
+  Ex: !mode transfer easy_tax unit_share_stun_seconds=45 tax_resource_sharing_amount=0.5

--- a/var/plugins/modecommand.py
+++ b/var/plugins/modecommand.py
@@ -40,8 +40,18 @@ def _conf():
 
 
 def _current_mod_name():
+    # The hosted game as the lobby knows it, e.g. "Beyond All Reason test-24450-6c81e38":
+    # the mod of SPADS's own battle, the same field spads.pl reads. None until the
+    # battle is open.
     try:
-        return _conf().get('modName')
+        lobby = spads.getLobbyInterface()
+        battle = lobby.getBattle()
+        battle_id = battle.get('battleId') if battle else None
+        if battle_id is None:
+            return None
+        mine = lobby.getBattles().get(battle_id) or lobby.getBattles().get(str(battle_id)) or {}
+        name = mine.get('mod')
+        return spads.fix_string(name) if name else None
     except Exception:
         return None
 
@@ -190,12 +200,20 @@ class ModeCommand:
     def __init__(self, context):
         spads.addSpadsCommandHandler({'mode': hSpadsMode})
         spads.slog("Plugin loaded (version %s)" % pluginVersion, 3)
-        # Warm the modes once SPADS has its config; modName is unset at load.
-        spads.addTimer('warm', 5, 0, _modes)
+        # Warm the modes once the battle is open; until then there is no hosted
+        # game to look up. The timer retires itself on the first success.
+        spads.addTimer('warm', 5, 5, _warm)
 
     def onUnload(self, reason):
         spads.removeSpadsCommandHandler(['mode'])
         spads.slog("Plugin unloaded", 3)
+
+
+def _warm():
+    if _current_mod_name() is None:
+        return
+    _modes()
+    spads.removeTimer('warm')
 
 
 def hSpadsMode(source, user, params, checkOnly):

--- a/var/plugins/modecommand.py
+++ b/var/plugins/modecommand.py
@@ -1,0 +1,271 @@
+import perl
+import re
+import os
+import json
+import threading
+import urllib.request
+
+spads = perl.ModeCommand
+
+pluginVersion = '0.2'
+requiredSpadsVersion = '0.12.29'
+
+
+# !mode applies one of the game's mode presets: modes.json, baked by BAR CI from
+# the game's modes/*.lua and published as a release asset (modes-<sha>.json for
+# the hosted commit, else modes-<channel>.json). Fetched in the background, cached,
+# with a host-dropped file as the last resort.
+# Local testing: MODECOMMAND_RELEASE_BASE, MODECOMMAND_MODES_VERSION (asset key),
+# MODECOMMAND_MODES_CHANNEL=test|stable.
+
+_PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+
+_DEFAULT_RELEASE_BASE = 'https://github.com/beyond-all-reason/Beyond-All-Reason/releases/download/modes'
+_CACHE_PATH = os.path.join(_PLUGIN_DIR, 'modes.cache.json')
+_LOCAL_PATHS = [
+    os.path.join(_PLUGIN_DIR, 'modes.json'),
+    '/opt/spads/var/plugins/modes.json',
+]
+_FETCH_TIMEOUT = 5
+_SCHEMA_VERSION = 1
+
+# Modes for the hosted version (modName); a rehost to another version refetches.
+_UNSET = object()
+_state = {'modName': _UNSET, 'data': {}, 'pending': None}
+
+
+def _conf():
+    try:
+        return spads.getSpadsConf()
+    except Exception:
+        return {}
+
+
+def _current_mod_name():
+    try:
+        return _conf().get('modName')
+    except Exception:
+        return None
+
+
+def _release_base():
+    return (os.environ.get('MODECOMMAND_RELEASE_BASE') or _DEFAULT_RELEASE_BASE).rstrip('/')
+
+
+def _channel(mod_name):
+    override = (os.environ.get('MODECOMMAND_MODES_CHANNEL') or 'auto').lower()
+    if override in ('test', 'stable'):
+        return override
+    return 'test' if (mod_name and 'test' in mod_name.lower()) else 'stable'
+
+
+def _commit_sha(mod_name):
+    # Trailing git short SHA of the hosted version ("...test-24450-6c81e38" -> "6c81e38").
+    override = os.environ.get('MODECOMMAND_MODES_VERSION')
+    if override:
+        return override.strip() or None
+    if not mod_name:
+        return None
+    m = re.search(r'-([0-9a-f]{7,40})\s*$', mod_name)
+    return m.group(1) if m else None
+
+
+def _fetch(mod_name):
+    # Worker thread: no spads.* calls here; log lines return as (message, level).
+    base = _release_base()
+    urls = []
+    sha = _commit_sha(mod_name)
+    if sha:
+        urls.append(('%s/modes-%s.json' % (base, sha), True))
+    urls.append(('%s/modes-%s.json' % (base, _channel(mod_name)), False))
+
+    log = []
+    for (url, pinned) in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT) as resp:
+                body = resp.read()
+            data = json.loads(body)
+            if not pinned and sha:
+                log.append(('mode: no modes asset pinned to commit %s; serving the rolling %s asset, '
+                            'which may not match the hosted version' % (sha, _channel(mod_name)), 2))
+            schema = data.get('schemaVersion') if isinstance(data, dict) else None
+            if schema != _SCHEMA_VERSION:
+                log.append(('mode: %s has schemaVersion %r, this plugin reads %r; modes may not apply correctly'
+                            % (url, schema, _SCHEMA_VERSION), 1))
+            try:
+                with open(_CACHE_PATH, 'wb') as f:
+                    f.write(body)
+            except OSError:
+                pass
+            return data, log
+        except Exception as e:
+            log.append(('mode: could not fetch %s: %s' % (url, e), 2))
+    return None, log
+
+
+def _load_local():
+    for path in [_CACHE_PATH] + _LOCAL_PATHS:
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            continue
+    return None
+
+
+def _start_fetch(mod_name):
+    pending = {'modName': mod_name, 'done': False, 'data': None, 'log': []}
+
+    def run():
+        try:
+            pending['data'], pending['log'] = _fetch(mod_name)
+        except Exception as e:
+            pending['data'], pending['log'] = None, [('mode: fetch failed: %s' % e, 2)]
+        pending['done'] = True
+
+    _state['pending'] = pending
+    threading.Thread(target=run, name='ModeCommand-fetch', daemon=True).start()
+    return pending
+
+
+def _collect_fetch():
+    pending = _state['pending']
+    if not pending or not pending['done']:
+        return
+    _state['pending'] = None
+    for (message, level) in pending['log']:
+        spads.slog(message, level)
+    if pending['data'] is not None and pending['modName'] == _state['modName']:
+        _state['data'] = _as_dict(pending['data'])
+        spads.slog('mode: modes for "%s" loaded' % pending['modName'], 3)
+
+
+def _modes():
+    # Never blocks: serves the cache while the fetch runs, then the fetched data.
+    _collect_fetch()
+    mod_name = _current_mod_name()
+    if mod_name != _state['modName']:
+        _state['modName'] = mod_name
+        local = _load_local()
+        _state['data'] = _as_dict(local)
+        if local is None:
+            spads.slog('mode: no cached modes for "%s"; !mode has nothing to apply until the fetch lands' % mod_name, 2)
+        else:
+            spads.slog('mode: serving cached modes for "%s" while the current ones are fetched' % mod_name, 3)
+        _start_fetch(mod_name)
+    return _state['data']
+
+
+def _as_dict(v):
+    # Lua's Json.encode writes an empty table as [], so never trust the shape.
+    return v if isinstance(v, dict) else {}
+
+globalPluginParams = {
+    'commandsFile': ['notNull'],
+    'helpFile': ['notNull'],
+}
+presetPluginParams = None
+
+
+def getVersion(pluginObject):
+    return pluginVersion
+
+def getRequiredSpadsVersion(pluginName):
+    return requiredSpadsVersion
+
+def getParams(pluginName):
+    return [globalPluginParams, presetPluginParams]
+
+
+class ModeCommand:
+
+    def __init__(self, context):
+        spads.addSpadsCommandHandler({'mode': hSpadsMode})
+        spads.slog("Plugin loaded (version %s)" % pluginVersion, 3)
+        _modes()
+
+    def onUnload(self, reason):
+        spads.removeSpadsCommandHandler(['mode'])
+        spads.slog("Plugin unloaded", 3)
+
+
+def hSpadsMode(source, user, params, checkOnly):
+    (source, user) = spads.fix_string(source, user)
+    for i in range(len(params)):
+        params[i] = spads.fix_string(params[i])
+
+    if len(params) < 2:
+        spads.invalidSyntax(user, 'mode')
+        return 0
+
+    category = params[0]
+    mode_key = params[1]
+    kv_params = params[2:]
+
+    category_data = _as_dict(_modes().get('categories')).get(category)
+    if not category_data:
+        spads.answer('Unknown mode category "%s"' % category)
+        return 0
+    presets = _as_dict(category_data.get('presets'))
+    preset = presets.get(mode_key)
+    if not preset:
+        valid = ', '.join(sorted(presets)) or '(none)'
+        spads.answer('Unknown mode "%s" for category "%s" (valid: %s)' % (mode_key, category, valid))
+        return 0
+
+    mod_options = _as_dict(preset.get('modOptions'))
+
+    settings = []
+    for param in kv_params:
+        m = re.match(r'^([^=]+)=(.*)$', param)
+        if not m:
+            spads.answer('Invalid parameter format "%s" (expected key=value)' % param)
+            return 0
+        settings.append((m.group(1).lower(), m.group(2)))
+
+    locked_keys = set(
+        key.lower() for key, spec in mod_options.items()
+        if isinstance(spec, dict) and spec.get('locked')
+    )
+
+    # Unknown keys are refused in the check phase, so a typo never reaches a vote.
+    valid_keys = set(k.lower() for k in mod_options)
+    for (key, _val) in settings:
+        if key not in valid_keys:
+            spads.answer('Unknown option "%s" for mode "%s %s" (valid: %s)'
+                         % (key, category, mode_key, ', '.join(sorted(valid_keys)) or '(none)'))
+            return 0
+
+    if checkOnly:
+        return 1
+
+    selector_key = category_data.get('selector') or ('%s_mode' % category)
+    spads.updateSetting('bSet', selector_key, mode_key)
+
+    # The full preset, then overrides; locked options keep the preset's value.
+    effective = {}
+    for (key, spec) in mod_options.items():
+        if isinstance(spec, dict) and 'value' in spec:
+            effective[key.lower()] = spec['value']
+    for (key, val) in settings:
+        if key not in locked_keys:
+            effective[key] = val
+
+    change_descs = ['%s=%s' % (selector_key, mode_key)]
+    for key in sorted(effective):
+        spads.updateSetting('bSet', str(key), str(effective[key]))
+        change_descs.append('%s=%s' % (key, effective[key]))
+
+    changes_str = ', '.join(change_descs)
+    mode_label = '%s %s' % (category, mode_key)
+    if changes_str:
+        spads.sayBattleAndGame('Mode "%s" applied by %s (%s)' % (mode_label, user, changes_str))
+    else:
+        spads.sayBattleAndGame('Mode "%s" applied by %s' % (mode_label, user))
+    if source == 'pv':
+        if changes_str:
+            spads.answer('Mode "%s" applied (%s)' % (mode_label, changes_str))
+        else:
+            spads.answer('Mode "%s" applied' % mode_label)
+
+    return 1

--- a/var/plugins/modecommand.py
+++ b/var/plugins/modecommand.py
@@ -2,7 +2,6 @@ import perl
 import re
 import os
 import json
-import threading
 import urllib.request
 
 spads = perl.ModeCommand
@@ -30,8 +29,7 @@ _FETCH_TIMEOUT = 5
 _SCHEMA_VERSION = 1
 
 # Modes for the hosted version (modName); a rehost to another version refetches.
-_UNSET = object()
-_state = {'modName': _UNSET, 'data': {}, 'pending': None}
+_state = {'modName': None, 'data': {}, 'pending': None}
 
 
 def _conf():
@@ -113,38 +111,48 @@ def _load_local():
     return None
 
 
-def _start_fetch(mod_name):
-    pending = {'modName': mod_name, 'done': False, 'data': None, 'log': []}
-
-    def run():
-        try:
-            pending['data'], pending['log'] = _fetch(mod_name)
-        except Exception as e:
-            pending['data'], pending['log'] = None, [('mode: fetch failed: %s' % e, 2)]
-        pending['done'] = True
-
-    _state['pending'] = pending
-    threading.Thread(target=run, name='ModeCommand-fetch', daemon=True).start()
-    return pending
+def _fetch_for_fork(mod_name):
+    # Runs in the forked child: one string crosses back to the parent.
+    data, log = _fetch(mod_name)
+    return json.dumps({'data': data, 'log': log, 'modName': mod_name})
 
 
-def _collect_fetch():
-    pending = _state['pending']
-    if not pending or not pending['done']:
-        return
+def _on_fetched(result):
+    # SPADS calls this in the main process once the child returns.
     _state['pending'] = None
-    for (message, level) in pending['log']:
+    try:
+        result = json.loads(spads.fix_string(result) if result is not None else '{}')
+    except Exception as e:
+        spads.slog('mode: unreadable fetch result: %s' % e, 1)
+        return
+    for (message, level) in result.get('log') or []:
         spads.slog(message, level)
-    if pending['data'] is not None and pending['modName'] == _state['modName']:
-        _state['data'] = _as_dict(pending['data'])
-        spads.slog('mode: modes for "%s" loaded' % pending['modName'], 3)
+    data = result.get('data')
+    if data is not None and result.get('modName') == _state['modName']:
+        _state['data'] = _as_dict(data)
+        spads.slog('mode: modes for "%s" loaded' % _state['modName'], 3)
+
+
+def _start_fetch(mod_name):
+    # SPADS's own async primitive: the fetch runs in a forked child and the
+    # callback runs here when it finishes. A Python thread would starve, since
+    # the interpreter only runs while Perl is calling into it.
+    if not spads.get_flag('can_fork'):
+        _on_fetched(_fetch_for_fork(mod_name))
+        return
+    _state['pending'] = mod_name
+    pid = spads.forkCall(lambda: _fetch_for_fork(mod_name), _on_fetched)
+    if not pid:
+        _state['pending'] = None
+        spads.slog('mode: could not fork the modes fetch', 1)
 
 
 def _modes():
-    # Never blocks: serves the cache while the fetch runs, then the fetched data.
-    _collect_fetch()
+    # Never blocks. The first lookup for a hosted version serves the last cached
+    # copy, or a host-dropped file, or {}, and starts the fetch; the callback
+    # swaps the fetched modes in when it lands. A rehost to another version repeats it.
     mod_name = _current_mod_name()
-    if mod_name != _state['modName']:
+    if mod_name is not None and mod_name != _state['modName'] and _state['pending'] != mod_name:
         _state['modName'] = mod_name
         local = _load_local()
         _state['data'] = _as_dict(local)
@@ -182,7 +190,8 @@ class ModeCommand:
     def __init__(self, context):
         spads.addSpadsCommandHandler({'mode': hSpadsMode})
         spads.slog("Plugin loaded (version %s)" % pluginVersion, 3)
-        _modes()
+        # Warm the modes once SPADS has its config; modName is unset at load.
+        spads.addTimer('warm', 5, 0, _modes)
 
     def onUnload(self, reason):
         spads.removeSpadsCommandHandler(['mode'])

--- a/var/plugins/test_modecommand.py
+++ b/var/plugins/test_modecommand.py
@@ -15,9 +15,27 @@ import unittest
 _calls = {'slog': [], 'answer': [], 'bSet': [], 'say': []}
 
 
+class _FakeLobby:
+    hosted = 'Beyond All Reason test-24450-abc1234'
+
+    def getBattle(self):
+        return {'battleId': '7'} if self.hosted else None
+
+    def getBattles(self):
+        return {'7': {'mod': self.hosted}} if self.hosted else {}
+
+
 class _FakeSpads:
+    lobby = _FakeLobby()
+
     def getSpadsConf(self):
-        return {'modName': 'Beyond All Reason test-24450-abc1234'}
+        return {}
+
+    def getLobbyInterface(self):
+        return self.lobby
+
+    def removeTimer(self, name):
+        _calls.setdefault('timers_removed', []).append(name)
 
     def slog(self, message, level):
         _calls['slog'].append((message, level))
@@ -128,12 +146,12 @@ class BackgroundFetch(unittest.TestCase):
     def test_nothing_is_fetched_before_spads_knows_the_hosted_version(self):
         modecommand._state.update({'modName': None, 'data': {}, 'pending': None})
         fake_perl.ModeCommand.released.clear()
-        fake_perl.ModeCommand.getSpadsConf = lambda: {}
+        fake_perl.ModeCommand.lobby.hosted = None
         try:
             self.assertEqual({}, modecommand._modes())
             self.assertEqual(0, len(fake_perl.ModeCommand.released))
         finally:
-            del fake_perl.ModeCommand.getSpadsConf
+            fake_perl.ModeCommand.lobby.hosted = _FakeLobby.hosted
 
 
 if __name__ == '__main__':

--- a/var/plugins/test_modecommand.py
+++ b/var/plugins/test_modecommand.py
@@ -43,6 +43,21 @@ class _FakeSpads:
     def sayBattleAndGame(self, message):
         _calls['say'].append(message)
 
+    def get_flag(self, name):
+        return True
+
+    def addTimer(self, name, delay, interval, callback):
+        _calls.setdefault('timers', []).append(name)
+
+    # forkCall stand-in: run the child function now, hand the result to the
+    # callback only when the test releases it, so "asynchronous" is observable.
+    released = []
+
+    def forkCall(self, fn, callback):
+        result = fn()
+        self.released.append(lambda: callback(result))
+        return 4242
+
 
 fake_perl = types.ModuleType('perl')
 fake_perl.ModeCommand = _FakeSpads()
@@ -98,26 +113,27 @@ class LockedKeys(unittest.TestCase):
 
 
 class BackgroundFetch(unittest.TestCase):
-    def test_the_first_lookup_never_waits_on_the_network(self):
+    def test_the_first_lookup_serves_the_cache_and_the_callback_swaps_in_the_fetch(self):
         modecommand._state.update({'modName': None, 'data': {}, 'pending': None})
-        gate = threading.Event()
-
-        def slow_fetch(mod_name):
-            gate.wait(5)
-            return MODES, [('fetched', 3)]
-
-        modecommand._fetch = slow_fetch
+        fake_perl.ModeCommand.released.clear()
+        modecommand._fetch = lambda mod_name: (MODES, [('fetched', 3)])
         modecommand._load_local = lambda: {'schemaVersion': 1, 'categories': {}}
-        started = time.time()
         first = modecommand._modes()
-        self.assertLess(time.time() - started, 1.0)
         self.assertEqual({}, first['categories'])
-        gate.set()
-        deadline = time.time() + 5
-        while modecommand._state['pending'] and time.time() < deadline:
-            time.sleep(0.01)
-            modecommand._modes()
+        self.assertEqual(1, len(fake_perl.ModeCommand.released))
+        fake_perl.ModeCommand.released.pop()()
         self.assertEqual(MODES['categories'], modecommand._modes()['categories'])
+        self.assertIn(('fetched', 3), _calls['slog'])
+
+    def test_nothing_is_fetched_before_spads_knows_the_hosted_version(self):
+        modecommand._state.update({'modName': None, 'data': {}, 'pending': None})
+        fake_perl.ModeCommand.released.clear()
+        fake_perl.ModeCommand.getSpadsConf = lambda: {}
+        try:
+            self.assertEqual({}, modecommand._modes())
+            self.assertEqual(0, len(fake_perl.ModeCommand.released))
+        finally:
+            del fake_perl.ModeCommand.getSpadsConf
 
 
 if __name__ == '__main__':

--- a/var/plugins/test_modecommand.py
+++ b/var/plugins/test_modecommand.py
@@ -1,0 +1,124 @@
+"""Unit tests for the parts of the ModeCommand plugin that do not need SPADS.
+
+Run from this directory: python3 -m unittest test_modecommand
+"""
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest
+
+# The plugin imports SPADS's perl bridge at module scope; stand one in.
+_calls = {'slog': [], 'answer': [], 'bSet': [], 'say': []}
+
+
+class _FakeSpads:
+    def getSpadsConf(self):
+        return {'modName': 'Beyond All Reason test-24450-abc1234'}
+
+    def slog(self, message, level):
+        _calls['slog'].append((message, level))
+
+    def addSpadsCommandHandler(self, handlers):
+        pass
+
+    def removeSpadsCommandHandler(self, names):
+        pass
+
+    def fix_string(self, *args):
+        return args if len(args) > 1 else args[0]
+
+    def invalidSyntax(self, user, command):
+        _calls['answer'].append('invalid syntax')
+
+    def answer(self, message):
+        _calls['answer'].append(message)
+
+    def updateSetting(self, kind, key, value):
+        _calls['bSet'].append((key, value))
+
+    def sayBattleAndGame(self, message):
+        _calls['say'].append(message)
+
+
+fake_perl = types.ModuleType('perl')
+fake_perl.ModeCommand = _FakeSpads()
+sys.modules['perl'] = fake_perl
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import modecommand  # noqa: E402
+
+
+def _reset(data, pending=None):
+    modecommand._state.update({'modName': 'Beyond All Reason test-24450-abc1234', 'data': data, 'pending': pending})
+    for v in _calls.values():
+        v.clear()
+
+
+MODES = {
+    'schemaVersion': 1,
+    'categories': {
+        'transfer': {
+            'selector': 'transfer_mode',
+            'presets': {
+                'enabled': {
+                    'modOptions': {
+                        'ResourceMult': {'value': '1', 'locked': True},
+                        'tax_rate': {'value': '0.1', 'locked': False},
+                    }
+                }
+            },
+        }
+    },
+}
+
+
+class ModesShape(unittest.TestCase):
+    def test_a_list_at_the_top_level_reads_as_no_modes(self):
+        modecommand._state.update({'modName': None, 'data': {}, 'pending': None})
+        modecommand._load_local = lambda: ['not', 'an', 'object']
+        modecommand._start_fetch = lambda mod_name: None
+        self.assertEqual({}, modecommand._modes())
+        self.assertEqual({}, modecommand._as_dict(modecommand._modes().get('categories')))
+
+
+class LockedKeys(unittest.TestCase):
+    def test_a_lock_holds_whatever_the_casing(self):
+        _reset(MODES)
+        modecommand.hSpadsMode('pv', 'alice', ['transfer', 'enabled', 'resourcemult=9'], False)
+        self.assertIn(('resourcemult', '1'), _calls['bSet'])
+        self.assertNotIn(('resourcemult', '9'), _calls['bSet'])
+
+    def test_an_unlocked_option_takes_the_override(self):
+        _reset(MODES)
+        modecommand.hSpadsMode('pv', 'alice', ['transfer', 'enabled', 'tax_rate=0.5'], False)
+        self.assertIn(('tax_rate', '0.5'), _calls['bSet'])
+
+
+class BackgroundFetch(unittest.TestCase):
+    def test_the_first_lookup_never_waits_on_the_network(self):
+        modecommand._state.update({'modName': None, 'data': {}, 'pending': None})
+        gate = threading.Event()
+
+        def slow_fetch(mod_name):
+            gate.wait(5)
+            return MODES, [('fetched', 3)]
+
+        modecommand._fetch = slow_fetch
+        modecommand._load_local = lambda: {'schemaVersion': 1, 'categories': {}}
+        started = time.time()
+        first = modecommand._modes()
+        self.assertLess(time.time() - started, 1.0)
+        self.assertEqual({}, first['categories'])
+        gate.set()
+        deadline = time.time() + 5
+        while modecommand._state['pending'] and time.time() < deadline:
+            time.sleep(0.01)
+            modecommand._modes()
+        self.assertEqual(MODES['categories'], modecommand._modes()['categories'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The SPADS half of the game modes work: `!mode <category> <modeName> [key=value ...]` applies one of the game's declared mode presets to the hosted battle. The lobby side is beyond-all-reason/BYAR-Chobby#1041; the modes themselves are beyond-all-reason/Beyond-All-Reason#8486.

A clean `!mode transfer easy_tax` sets the category's selector and the preset's full effective option set, so a client that sends only the mode key gets the whole preset. Extra `key=value` params override the preset except locked options, which are clamped to the preset's value; keys are compared lowercase. Privilege mirrors bSet: a vote in a stopped battle, direct for admins.

The presets come from `modes.json` for the hosted version, which BAR CI bakes from the same `modes/*.lua` and publishes as a release asset, `modes-<sha>.json` pinned to the hosted commit, `modes-<channel>.json` otherwise. The fetch runs on a worker thread off the command path. Version mismatches trigger loud warnings in the log.

This adds the plugin and its two conf files only. It is not added to `autoLoadPlugins`; enabling it on the cluster is a separate change.

### LLMs
Yes, claude Fable 5.1 but the code was written long ago by some variant of Opus. Reviewed and tested by muah.